### PR TITLE
FEATURE: Add ability to disable bundles via config

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,11 @@ module.exports.init = function (rootPath, nodecgVersion, nodecgConfig, Logger) {
 			return;
 		}
 
+		if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.disabled.indexOf(bundleFolderName) > -1) {
+			log.debug('Not loading bundle ' + bundleFolderName + ' as it is disabled in config');
+			return;
+		}
+
 		// Parse each bundle and push the result onto the _bundles array
 		let bundle;
 		const bundleCfgPath = path.join(rootPath, '/cfg/', bundleFolderName + '.json');

--- a/test/fixtures/bundles/test-disabled-bundle/package.json
+++ b/test/fixtures/bundles/test-disabled-bundle/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-disabled-bundle",
+  "version": "1.0.0",
+  "homepage": "http://github.com/nodecg",
+  "author": "madmatt <matt@madman.net.nz>",
+  "description": "A test bundle that shouldn't be loaded",
+  "license": "MIT",
+  "nodecg": {
+    "compatibleRange": "~0.7.0"
+  }
+}

--- a/test/manager.spec.js
+++ b/test/manager.spec.js
@@ -18,8 +18,16 @@ before(function (done) {
 
 	wrench.copyDirSyncRecursive('test/fixtures', '_workingTest', {forceDelete: true});
 
+	const nodecgConfig = {
+		bundles: {
+			disabled: [
+				'test-disabled-bundle'
+			]
+		}
+	};
+
 	this.bundleManager = require('../index.js');
-	this.bundleManager.init('_workingTest', '0.7.0', {}, Logger).then(() => {
+	this.bundleManager.init('_workingTest', '0.7.0', nodecgConfig, Logger).then(() => {
 		// Needs a little extra wait time for some reason.
 		// Without this, tests randomly fail.
 		setTimeout(() => {
@@ -36,6 +44,11 @@ describe('loader', () => {
 
 	it('should not load bundles with a non-satisfactory nodecg.compatibleRange', function () {
 		const bundle = this.bundleManager.find('incompatible-range');
+		assert.isUndefined(bundle);
+	});
+
+	it('should not load a bundle that has been disabled', function () {
+		const bundle = this.bundleManager.find('test-disabled-bundle');
 		assert.isUndefined(bundle);
 	});
 });


### PR DESCRIPTION
This allows bundles to be disabled by simply add the following to your `nodecg.json` in the project root:
```
{
    "bundles": {
        "disabled": [
            "name-of-bundle",
            "name-of-second-bundle"
        ]
    }
}
```

This is paired with pull request nodecg/nodecg#248.

These two pull requests together close nodecg/nodecg#124 and nodecg/nodecg#126.